### PR TITLE
Disabled generation for eidolon

### DIFF
--- a/config/eidolon-common.toml
+++ b/config/eidolon-common.toml
@@ -1,0 +1,4 @@
+[world]
+labEnabled = false
+strayTowerEnabled = false
+catacombEnabled = false


### PR DESCRIPTION
Temporary fix until eidolon world gen can be configured for specific worlds