### PR TITLE
Update allthetweaks-common.toml

### DIFF
--- a/config/allthetweaks-common.toml
+++ b/config/allthetweaks-common.toml
@@ -1,4 +1,25 @@
 
 [packmode]
+	#ATM = 0 SLOP = 1 SKY = 2 MAGIC = 3 EXPERT = 4
+	#Range: 0 ~ 4
 	enable = 2
+
+[discord]
+	#Enable Discord Rich Prescence
+	discord = true
+
+[packversionmaj]
+	#Pack Release Version Format : X
+	#Range: 0 ~ 32768
+	major = 1
+
+[packversionmin]
+	#Pack Minor Version : X
+	#Range: 0 ~ 32768
+	minor = 1
+
+[packversionminrev]
+	#Pack Minor Version Revision : X
+	#Range: 0 ~ 32768
+	minorrev = 0
 


### PR DESCRIPTION
update to tweaks 1.3.5+ with pack major/minor/minor rev version for main screen modpack version display and discord rich prescence toggle, i am assuming a pack version of 1.1.0 for the next release, change if necessary, this will need to be updated each version update, but this will give us better bug reports as players will know from the main screen of the game now what version they are running,this will automatically configure to display the pack name based on packmode, alongside the versions entered here, for example 

![image](https://user-images.githubusercontent.com/1524819/118915712-c4e2fb80-b8ea-11eb-8ebc-49b28cc597cf.png)
